### PR TITLE
feat: add personal-files slot for mutt configuration

### DIFF
--- a/.github/plug-declaration.json
+++ b/.github/plug-declaration.json
@@ -1,0 +1,3 @@
+{
+    "personal-files": { "allow-installation": true }
+}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ snap install mutt
 
 <p align="center">Published for <img src="https://raw.githubusercontent.com/anythingcodes/slack-emoji-for-techies/gh-pages/emoji/tux.png" align="top" width="24" /> with :gift_heart: by Snapcrafters</p>
 
+## Snap Configuration
+
+| option          | default | description                                                                                                                                                                                                                 |
+| --------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `use-real-home` | `false` | If set to `true`, `mutt` will look for configuration in your home directory in either `$HOME/.muttrc`, `$HOME/.mutt` or `$HOME/.config/mutt`, rather than using configuration stored inside the Snap's user data directory. |
+
+You can change Snap configuration by running `snap set mutt <key>=<value>`. For example, `snap set mutt use-real-home=true`.
+
 ## How to contribute to this snap
 
 Thanks for your interest! Below you find instructions to help you contribute to this snap.

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# On Fedora $SNAP is under /var and there is some magic to map it to /snap.
+# We need to handle that case and reset $SNAP
+SNAP="${SNAP//\/var\/lib\/snapd/}"
+
+use_real_home="$(snapctl get use-real-home)"
+if [[ -z "$use_real_home" ]]; then
+    snapctl set use-real-home=false
+fi

--- a/snap/local/bin/mutt-wrapper
+++ b/snap/local/bin/mutt-wrapper
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the configure hook which sets defaults for any config options
+"${SNAP}/snap/hooks/configure"
+
+export HOME="$SNAP_USER_COMMON"
+
+use_real_home="$(snapctl get use-real-home)"
+if [[ "${use_real_home}" == "true" ]]; then
+    export HOME="$SNAP_REAL_HOME"
+fi
+
+exec "${SNAP}/usr/local/bin/mutt" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,9 +49,8 @@ architectures:
 apps:
   mutt:
     environment:
-      HOME: "$SNAP_USER_COMMON"
       TERMINFO_DIRS: $SNAP/lib/terminfo:$SNAP/usr/share/terminfo
-    command: usr/local/bin/mutt
+    command: bin/mutt-wrapper
     plugs:
       - network
       - home
@@ -142,3 +141,8 @@ parts:
       tic -xe alacritty,alacritty-direct $CRAFT_PART_SRC/alacritty.info -o .
       mkdir -p $CRAFT_PRIME/lib/terminfo/a/
       cp a/alacritty* $CRAFT_PRIME/lib/terminfo/a/
+
+  local-parts:
+    plugin: dump
+    source: ./snap/local
+    source-type: local

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,6 +55,15 @@ apps:
     plugs:
       - network
       - home
+      - dot-mutt
+
+plugs:
+  dot-mutt:
+    interface: personal-files
+    write:
+      - $HOME/.mutt
+      - $HOME/.muttrc
+      - $HOME/.config/mutt
 
 parts:
   mutt:


### PR DESCRIPTION
This PR adds a plug declaration for Mutt such that it can read/write the various default configuration locations as specified in the docs.

Will need approval from the snap store, post in Discourse will follow.

The config option is required so that people can opt into this behaviour, but that it doesn't change by default for people already using the snap.