### PR TITLE
fix: flatten mutt ppc64el platform

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,6 @@ platforms:
   arm64:
   s390x:
   ppc64el:
-    build-on: [amd64, armhf, arm64, s390x, ppc64el]
 
 apps:
   mutt:


### PR DESCRIPTION
Fixes the broken `platforms` definition for `ppc64el` in `snap/snapcraft.yaml`.

Change:
- Drops the nested `build-on` clause from `platforms.ppc64el`, making it a flat map entry like the other architectures.

Verification:
- Parsed `snap/snapcraft.yaml` with Python/YAML.
- Asserted `platforms.ppc64el` is a flat key with no nested value.
- Asserted the platforms block contains no `build-on` clauses.
- Ran `git diff --check`.
- Commit is signed.

@jnsgruk please review.
